### PR TITLE
Add Composer 2 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "composer-plugin",
     "require": {
         "google/apiclient": "^2.0",
-        "composer-plugin-api": "^1.1"
+        "composer-plugin-api": "^1.1 || ^2.0"
     },
     "license": "GPL-3.0-or-later",
     "authors": [

--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -33,4 +33,14 @@ class ComposerPlugin implements PluginInterface, Capable
       'Composer\Plugin\Capability\CommandProvider' => 'NickWilde1990\DrupalSpecToolCommands\Command\DrupalSpecCommands',
     ];
   }
+
+  public function deactivate(Composer $composer, IOInterface $io)
+  {
+    // Nothing to deactivate.
+  }
+
+  public function uninstall(Composer $composer, IOInterface $io)
+  {
+    // Nothing to uninstall.
+  }
 }


### PR DESCRIPTION
The only bits of the Composer plugin API that have changed are the two extra methods in `PluginInterface` which we need to implement in `ComposerPlugin`.